### PR TITLE
Fixed: cannot import because of wrong loaded class MessageHandler

### DIFF
--- a/src/app/code/community/C4B/XmlImport/Model/Products.php
+++ b/src/app/code/community/C4B/XmlImport/Model/Products.php
@@ -26,7 +26,7 @@ class C4B_XmlImport_Model_Products
     public function validateFile($filePath)
     {
         /* @var $messageHandler C4B_ProductImport_Model_MessageHandler */
-        $messageHandler = Mage::getSingleton('productimport/messageHandler');
+        $messageHandler = Mage::getSingleton('xmlimport/messageHandler');
         $result = self::VALIDATION_RESULT_OK;
         $nodeCount = 0;
         $xmlParser = xml_parser_create();


### PR DESCRIPTION
Hi, 

running the shell script in your current master branch creates a fatal error, because the "xmlimport/messageHandler" model is loaded as "productimport/messageHandler".

Best regards,

schnere
